### PR TITLE
Splits the input shares to 1/x'th of the edges

### DIFF
--- a/lib/refinery/slot.rb
+++ b/lib/refinery/slot.rb
@@ -91,6 +91,8 @@ module Refinery
             # Special-case for when a node demand is zero, and contains a slot
             # with "normal" links, and a slot with overflow links.
             set(:share, 0.0)
+          elsif node_demand.zero? && others.sum(&:demand).zero?
+            set(:share, 1.0 / (others.count + 1))
           elsif node_demand.zero? && others.all?(&:share)
             # Opposite of the special case above.
             set(:share, 1.0 - others.sum(&:share))

--- a/spec/integration/zero_demand_share_spec.rb
+++ b/spec/integration/zero_demand_share_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+
+describe 'Graph calculations; with three children' do
+  let!(:mother)  { graph.add Refinery::Node.new(:mother) }
+  let!(:child)   { graph.add Refinery::Node.new(:child) }
+  let!(:child_2) { graph.add Refinery::Node.new(:child_2) }
+  let!(:child_3) { graph.add Refinery::Node.new(:child_3) }
+
+  context 'with the same carriers' do
+    let!(:mc1_edge) { child.connect_to(mother, :electricity) }
+    let!(:mc2_edge) { child_2.connect_to(mother, :gas) }
+    let!(:mc3_edge) { child_3.connect_to(mother, :superpowers) }
+
+    context 'when the parent is missing demand' do
+      #                        [M]
+      #                      / / \
+      #           __________/ /   \
+      #          /           /     \
+      #    (0) [C1]    (0) [C2]   [C3] (0)
+      before do
+        child.set(:demand, 0)
+        child_2.set(:demand, 0)
+        child_3.set(:demand, 0)
+        calculate!
+      end
+
+      it 'sets demand for the parent' do
+        expect(mother).to have_demand.of(0.0)
+      end
+
+      it 'sets slot shares' do
+        expect(mother.slots.in.map { |slot| slot.share }).to eq([
+          (1.0/3.0), (1.0/3.0), (1.0/3.0)
+        ])
+      end
+
+      it { expect(graph).to validate }
+    end
+  end
+end

--- a/spec/refinery/slot_spec.rb
+++ b/spec/refinery/slot_spec.rb
@@ -137,16 +137,6 @@ module Refinery
             expect(slot.share).to eq(2.0 / 3.0)
           end
         end # and demands are known for all slots
-
-        context 'and demand of the node is zero' do
-          before do
-            parent.set(:demand, 0)
-          end
-
-          it 'does not calculate the slot share' do
-            expect(slot.share).to be_nil
-          end
-        end
       end # as one of many carriers on the node
     end # share
   end # Slot


### PR DESCRIPTION
Fixes: https://github.com/quintel/refinery/issues/58