### PR TITLE
Heat modelling changes for the built environment

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,13 +7,15 @@ agent:
 blocks:
   - name: RSpec
     task:
+      prologue:
+        commands:
+          - checkout
+          - cache restore
+          - bundle install
+          - cache store
       jobs:
         - name: Test
           commands:
-            - checkout
-            - cache restore
-            - bundle install
-            - cache store
             - bundle exec rspec
           matrix:
             - env_var: RUBY_VERSION

--- a/lib/refinery/calculators/base.rb
+++ b/lib/refinery/calculators/base.rb
@@ -15,6 +15,7 @@ module Refinery
       # Public: The object which the calculator calculates.
       attr_reader :model
 
+
       # Public: Creates a new calculator responsible for figuring out the
       # unknown attributes for the given +model+. Calculator is a base class
       # and should be extended with the logic needed to compute the values.
@@ -56,6 +57,12 @@ module Refinery
       # Returns true or false.
       def calculated?
         @calculated
+      end
+
+      # Public: Returns true if the calculation of this part of the graph is
+      # paused
+      def paused?
+        @model.wait?
       end
 
       # Public: A human-readable version of the calculator for debugging.

--- a/lib/refinery/catalyst/calculators.rb
+++ b/lib/refinery/catalyst/calculators.rb
@@ -95,7 +95,7 @@ module Refinery
       def uncalculated
         @graph.tsort { |e| e.get(:type) != :overflow }.map do |node|
           [ node.calculator, *node.out_edges.map(&:calculator).to_a ]
-        end.flatten.reject(&:calculated?).reverse
+        end.flatten.reject(&:calculated?).reject(&:paused?).reverse
       end
     end
   end

--- a/lib/refinery/edge.rb
+++ b/lib/refinery/edge.rb
@@ -21,6 +21,18 @@ module Refinery
       get(:demand)
     end
 
+    def wait?
+      @paused || false
+    end
+
+    def wait!
+      @paused = true
+    end
+
+    def continue!
+      @paused = false
+    end
+
     def inspect
       super.sub(/>$/, " (type=#{get(:type)})>")
     end

--- a/lib/refinery/node.rb
+++ b/lib/refinery/node.rb
@@ -36,6 +36,18 @@ module Refinery
       get(:demand)
     end
 
+    def wait?
+      @paused || false
+    end
+
+    def wait!
+      @paused = true
+    end
+
+    def continue!
+      @paused = false
+    end
+
     # Public: The demand of the node for a given +carrier+.
     #
     # If the node demands a total of 200 energy, and its incoming gas slot has


### PR DESCRIPTION
Modelling of heat demand in the built environment has been updated. Summarized:

- Residences are set to four types: apartments, detached houses, semi-detached houses, terraced houses
- Residences are split into 6 construction periods: before 1945, 1945-1964, 1965-1984, 1985-2004, 2005 to present and future
- Buildings are split into 2 construction periods: present and future
- Useful space heating demand is no longer aggregated to a single node, but each residence of a certain type and construction period is connected to all heating technologies, the same goes for buildings
- Merit orders are added to determine allocation of technologies to residences
- Dataset initialisation (refinery and atlas) and required data (etdataset and etlocal) is updated
- Frontend charts, slides and sliders are updated
- Insulation has been changed, instead of setting a demand reduction, the typical useful demand of each residence and building can be adjusted
- Insulation costs queries are updated
- Useful demand can be assigned two different curves, depending on the technology one of the curves will be selected
- Deficits are calculated based on the capacity of the technology and the hourly demand of each residence and building

Goes with

- https://github.com/quintel/fever/pull/1
- https://github.com/quintel/refinery/pull/61
- https://github.com/quintel/atlas/pull/164
- https://github.com/quintel/etengine/pull/1386
- https://github.com/quintel/etsource/pull/2997
- https://github.com/quintel/etmodel/pull/4193
- https://github.com/quintel/etdataset/pull/989
- https://github.com/quintel/etlocal/pull/503