### PR TITLE
CTM-ETM coupling: generic transformation nodes

### DIFF
--- a/lib/refinery/catalyst/calculators.rb
+++ b/lib/refinery/catalyst/calculators.rb
@@ -93,7 +93,7 @@ module Refinery
       #
       # Returns an array of calculators.
       def uncalculated
-        @graph.tsort { |e| e.get(:type) != :overflow && !e.get(:excluded) }.map do |node|
+        @graph.tsort { |e| e.get(:type) != :overflow && !e.get(:circular) }.map do |node|
           [ node.calculator, *node.out_edges.map(&:calculator).to_a ]
         end.flatten.reject(&:calculated?).reject(&:paused?).reverse
       end

--- a/lib/refinery/catalyst/calculators.rb
+++ b/lib/refinery/catalyst/calculators.rb
@@ -93,7 +93,7 @@ module Refinery
       #
       # Returns an array of calculators.
       def uncalculated
-        @graph.tsort { |e| e.get(:type) != :overflow }.map do |node|
+        @graph.tsort { |e| e.get(:type) != :overflow && !e.get(:excluded) }.map do |node|
           [ node.calculator, *node.out_edges.map(&:calculator).to_a ]
         end.flatten.reject(&:calculated?).reject(&:paused?).reverse
       end

--- a/lib/refinery/catalyst/calculators.rb
+++ b/lib/refinery/catalyst/calculators.rb
@@ -93,7 +93,7 @@ module Refinery
       #
       # Returns an array of calculators.
       def uncalculated
-        @graph.tsort { |e| e.get(:type) != :overflow && !e.get(:circular) }.map do |node|
+        @graph.tsort { |e| e.get(:type) != :overflow && e.get(:type) != :circular }.map do |node|
           [ node.calculator, *node.out_edges.map(&:calculator).to_a ]
         end.flatten.reject(&:calculated?).reject(&:paused?).reverse
       end

--- a/lib/refinery/slot.rb
+++ b/lib/refinery/slot.rb
@@ -127,7 +127,7 @@ module Refinery
     end
 
     def inspect
-      "#<#{self.class.name} (#{@direction}, #{@carrier}) " \
+      "#<#{self.class.name} (#{@direction}, #{@carrier}) #{get(:type)}" \
         "node=#{@node.key.inspect}>"
     end
   end


### PR DESCRIPTION
Allows for circularities in the graph by skipping edges marked as circular in the toplogical sort