### PR TITLE
Prep gem for Ruby 4.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,20 +7,18 @@ agent:
 blocks:
   - name: RSpec
     task:
-      prologue:
-        commands:
-          - checkout
-          - cache restore
-          - bundle install
-          - cache store
       jobs:
         - name: Test
           commands:
+            - checkout
+            - sem-version ruby $RUBY_VERSION
+            - gem install bundler -v ">= 2.0"
+            - bundle install
             - bundle exec rspec
           matrix:
             - env_var: RUBY_VERSION
               values:
-                - 2.7.5
-                - 3.1.1
+                - '3.3'
+                - '4.0'
       secrets:
         - name: Refinery

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,5 +20,3 @@ blocks:
               values:
                 - '3.3'
                 - '4.0'
-      secrets:
-        - name: Refinery

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ group :test do
   gem 'rspec', '~> 3.11'
   gem 'rspec-collection_matchers'
   gem 'simplecov',               require: false
-  gem 'codecov',                 require: false
 end
 
 group :extras do

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -9,8 +9,3 @@ SimpleCov.start do
   add_filter('/lib/refinery/graph_debugger')
   add_filter('/lib/refinery/catalyst/visual_calculator')
 end
-
-if ENV['CI']
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end


### PR DESCRIPTION
#### Context

In an ongoing effort to prepare the internal gems for the upcoming Ruby4/Rails8 update, we updated their semaphore checks to use versions 3.3 and 4.0. Then run their RSpec tests locally against this 2 versions to identify any early issues (at gem level) and fix them.

#### Implemented changes

- refinery: Update Ruby version checks to 3.3/4.0
- fever: Update Ruby version checks to 3.3/4.0
- merit: Update Ruby version checks to 3.3/4.0 and add csv dependency
- atlas: Update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0 
- identity_rails: Add simplecov, update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0
- transformer: Add simplecov, unpin ruby-version then set Ruby version checks for 3.3/4.0 
- rubel: Add rspec and simplecov, fix some specs then set Ruby version checks for 3.3/4.0
- osmosis: Standarize simplecov, add bigdecimal dependency, fix some specs then set Ruby version checks for 3.3/4.0
- turbine: Standarize simplecov, add rspec-collection_matchers, fix specs then set Ruby version checks for 3.3/4.0

#### Related

Goes with pull requests:
- refinery: https://github.com/quintel/refinery/pull/63 [THIS ONE]
- fever: https://github.com/quintel/fever/pull/2
- merit: https://github.com/quintel/merit/pull/160
- atlas: https://github.com/quintel/atlas/pull/187
- identity_rails: https://github.com/quintel/identity_rails/pull/7
- transformer: https://github.com/quintel/transformer/pull/19
- rubel: https://github.com/quintel/rubel/pull/1
- osmosis: https://github.com/quintel/osmosis/pull/1
- turbine: https://github.com/quintel/turbine/pull/5

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review